### PR TITLE
Fix colors for PowerShell in ConEmu and Windows Terminal

### DIFF
--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -8,25 +8,16 @@ Get-ChildItem -Path $scriptDir\functions -Recurse -File -Include "*.ps1" -ErrorA
     . $_.FullName
 }
 
-$script:WindowsPowerShell = $PSVersionTable.PSEdition -eq "Desktop"
 $script:ansiEscape = "$([char]27)["
 
 function getTermColor {
     param ($hex, $xterm, $fg, $consoleColor) 
 
-    if ($env:WT_SESSION)  {
-        $x = "$($ansiEscape)38;5;$($xterm)m"
-    } else {
-        $x = "$($ansiEscape)$($fg)m"
-    }
-
     return [PSCustomObject]@{
-        xterm =  $x
+        xterm = "$($ansiEscape)$($fg)m"
         hex = $hex
         termColor = $consoleColor
     }
-
-    return
 }
 
 function colorPromptText {
@@ -38,12 +29,12 @@ function colorPromptText {
 $colors = [PSCustomObject]@{
     Red     = getTermColor 0xdc322f 160 31 Red
     Orange  = getTermColor 0xcb4b16 166
-    Yellow  = getTermColor 0xb58900 136 93 DarkYellow
-    Green   = getTermColor 0x859900 64  33 Green
-    Blue    = getTermColor 0x268bd2 33  94 DarkBlue
-    Cyan    = getTermColor 0x2aa198 37  94 DarkCyan
+    Yellow  = getTermColor 0xb58900 136 33 DarkYellow
+    Green   = getTermColor 0x859900 64  32 Green
+    Blue    = getTermColor 0x268bd2 33  34 DarkBlue
+    Cyan    = getTermColor 0x2aa198 37  36 DarkCyan
     Violet  = getTermColor 0x6c71c4 61  35
-    Magenta = getTermColor 0xd33682 125 95 DarkMagenta
+    Magenta = getTermColor 0xd33682 125 35 DarkMagenta
 
     Base00  = getTermColor 0x657b83 241
     Base01  = getTermColor 0x586e75 240
@@ -95,57 +86,25 @@ Set-PSReadLineOption -HistorySearchCursorMovesToEnd
 Set-PSReadlineKeyHandler -Key UpArrow -Function HistorySearchBackward
 Set-PSReadlineKeyHandler -Key DownArrow -Function HistorySearchForward
 
-if ((Get-Module -Name PSReadline).Version.Major -lt 2)
-{
-    Set-PSReadlineOption -TokenKind Parameter -ForegroundColor DarkMagenta
-    Set-PSReadlineOption -TokenKind Operator -ForegroundColor DarkMagenta
-}
-else
-{
-    Set-PSReadLineOption -Colors @{
-        "Parameter" = [System.ConsoleColor]::DarkMagenta;
-        "Operator" = [System.ConsoleColor]::DarkMagenta;
-    }
+Set-PSReadLineOption -Colors @{
+    Command = $colors.Yellow.xterm
+    Comment = $colors.Base00.xterm
+    Error = $colors.Red.xterm
+    Keyword = $colors.Green.xterm
+    Operator = $colors.Magenta.xterm
+    Parameter = $colors.Magenta.xterm
+    String = $colors.Blue.xterm
+    Variable = $colors.Green.xterm
 }
 
 Import-Module posh-git
-
-if ($null -ne $env:WT_SESSION -and -not $script:WindowsPowerShell) {
-    Set-PSReadLineOption -Colors @{
-        Command = $colors.Yellow.xterm
-        Comment = $colors.Base00.xterm
-        Error = $colors.Red.xterm
-        Keyword = $colors.Green.xterm
-        Operator = $colors.Magenta.xterm
-        Parameter = $colors.Magenta.xterm
-        String = $colors.Blue.xterm
-        Variable = $colors.Green.xterm
-    }
-
-    $GitPromptSettings.BranchColor.ForegroundColor = $colors.Cyan.hex
-    $GitPromptSettings.BranchAheadStatusSymbol.ForegroundColor = $colors.Green.hex
-    $GitPromptSettings.BranchBehindAndAheadStatusSymbol.ForegroundColor = $colors.Yellow.hex
-} else {
-    if (-not $script:WindowsPowerShell) {
-        Set-PSReadLineOption -Colors @{
-            Command = "`e[93m";
-            Parameter = "`e[35m";
-            Operator = "`e[35m";
-        }
-    } else {
-        Set-PSReadLineOption -Colors @{
-            Command = [ConsoleColor]::DarkYellow
-            Parameter = [ConsoleColor]::DarkMagenta
-            Operator = [ConsoleColor]::DarkMagenta
-        }
-
-    }
-}
-
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
-
+$GitPromptSettings.BranchColor.ForegroundColor = $colors.Cyan.hex
+$GitPromptSettings.BranchAheadStatusSymbol.ForegroundColor = $colors.Green.hex
+$GitPromptSettings.BranchBehindAndAheadStatusSymbol.ForegroundColor = $colors.Yellow.hex
 $GitPromptSettings.DefaultPromptPath = ""
 $GitPromptSettings.DefaultPromptBeforeSuffix.Text = "`n"
+
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 
 Register-ArgumentCompleter -Native -CommandName winget -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -25,10 +25,10 @@ function getTermColor {
     return
 }
 
-function coloredText {
+function colorPromptText {
     param ($color, $text)
 
-    return "$color$text`e[m"
+    return Write-Prompt "$color$text`e[m"
 }
 
 $colors = [PSCustomObject]@{
@@ -56,7 +56,7 @@ $colors = [PSCustomObject]@{
 function global:prompt {
 	$realLASTEXITCODE = $LASTEXITCODE
 
-    $prompt = Write-Prompt (coloredText $colors.Blue.xterm "$env:USERNAME@$env:COMPUTERNAME ")
+    $prompt = colorPromptText $colors.Blue.xterm "$env:USERNAME@$env:COMPUTERNAME "
 
 	$path = ""
 	if ($pwd.ProviderPath -eq $env:USERPROFILE) {
@@ -71,9 +71,9 @@ function global:prompt {
 		}
 	}
 
-    $prompt += Write-Prompt (coloredText $colors.Yellow.xterm "$path")
-    $prompt += Write-Prompt (coloredText $colors.Base1.xterm "  ")
-    $prompt += Write-Prompt (coloredText $colors.Blue.xterm "$(Get-Date -uFormat "%H:%M:%S")")
+    $prompt += colorPromptText $colors.Yellow.xterm "$path"
+    $prompt += colorPromptText $colors.Base1.xterm "  "
+    $prompt += colorPromptText $colors.Blue.xterm "$(Get-Date -uFormat "%H:%M:%S")"
     $prompt += & $GitPromptScriptBlock
 
 	$global:LASTEXITCODE = $realLASTEXITCODE
@@ -111,6 +111,7 @@ if ($env:WT_SESSION) {
         Command = $colors.Yellow.xterm
         Comment = $colors.Base00.xterm
         Error = $colors.Red.xterm
+        Keyword = $colors.Green.xterm
         Operator = $colors.Magenta.xterm
         Parameter = $colors.Magenta.xterm
         String = $colors.Blue.xterm

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -97,14 +97,14 @@ Set-PSReadLineOption -Colors @{
     Variable = $colors.Green.xterm
 }
 
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
+
 Import-Module posh-git
 $GitPromptSettings.BranchColor.ForegroundColor = $colors.Cyan.hex
 $GitPromptSettings.BranchAheadStatusSymbol.ForegroundColor = $colors.Green.hex
 $GitPromptSettings.BranchBehindAndAheadStatusSymbol.ForegroundColor = $colors.Yellow.hex
 $GitPromptSettings.DefaultPromptPath = ""
 $GitPromptSettings.DefaultPromptBeforeSuffix.Text = "`n"
-
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 
 Register-ArgumentCompleter -Native -CommandName winget -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -8,6 +8,39 @@ Get-ChildItem -Path $scriptDir\functions -Recurse -File -Include "*.ps1" -ErrorA
     . $_.FullName
 }
 
+function getTermColor {
+    param ($value)
+
+    return "`e[38;5;$($value)m"
+}
+
+function coloredText {
+    param ($color, $text)
+
+    return "$color$text`e[m"
+}
+
+$colors = [PSCustomObject]@{
+    Red = getTermColor 160
+    Orange = getTermColor 166
+    Yellow = getTermColor 136
+    Green = getTermColor 64
+    Blue = getTermColor 33
+    Cyan = getTermColor 37
+    Violet = getTermColor 61
+    Magenta = getTermColor 125
+
+    Base00 = getTermColor 241
+    Base01 = getTermColor 240
+    Base02 = getTermColor 235
+    Base03 = getTermColor 234
+
+    Base0 = getTermColor 244
+    Base1 = getTermColor 245
+    Base2 = getTermColor 254
+    Base3 = getTermColor 230
+}
+
 # Prompt 
 function global:prompt {
 	$realLASTEXITCODE = $LASTEXITCODE
@@ -57,6 +90,24 @@ else
     Set-PSReadLineOption -Colors @{
         "Parameter" = [System.ConsoleColor]::DarkMagenta;
         "Operator" = [System.ConsoleColor]::DarkMagenta;
+    }
+}
+
+if ($env:WT_SESSION) {
+    Set-PSReadLineOption -Colors @{
+        Command = $colors.Yellow
+        Comment = $colors.Base00
+        Error = $colors.Red
+        Operator = $colors.Magenta
+        Parameter = $colors.Magenta
+        String = $colors.Blue
+        Variable = $colors.Green
+    }
+} else {
+    Set-PSReadLineOption -Colors @{
+        Command = "`e[93m";
+        Parameter = "`e[35m";
+        Operator = "`e[35m";
     }
 }
 

--- a/windows/ConEmu.xml
+++ b/windows/ConEmu.xml
@@ -89,27 +89,8 @@
 			<value name="CmdLineHistory" type="multi">
 				<line data="{PowerShell::PowerShell}"/>
 				<line data="{PowerShell::Core}"/>
-				<line data="{dev::VS Dev}"/>
 				<line data="{PowerShell::Core (Admin)}"/>
 				<line data="{PowerShell::PowerShell (Admin)}"/>
-				<line data="{cmd::cmd}"/>
-				<line data="{cmd::cmd (Admin)}"/>
-				<line data="{CBT::dp-main-2}"/>
-				<line data="{CBT::dp-main}"/>
-				<line data="{bash::cygwin}"/>
-				<line data="{CBT::dp-main-4}"/>
-				<line data="{CBT::dp-main-3}"/>
-				<line data="{PowerShell}"/>
-				<line data="{bash::Git bash}"/>
-				<line data="{PowerShell (Admin)}"/>
-				<line data="{bash}"/>
-				<line data="{VS Dev}"/>
-				<line data="{cmd}"/>
-				<line data="{cmd (Admin)}"/>
-				<line data="cmd.exe"/>
-				<line data="\"/>
-				<line data="C:\windows\system32\cmd.exe"/>
-				<line data='powershell.exe -noexit -command "set-location c:\\users\\brgold"'/>
 			</value>
 			<value name="SingleInstance" type="hex" data="00"/>
 			<value name="ShowHelpTooltips" type="hex" data="01"/>
@@ -728,29 +709,6 @@
 					<value name="ColorTable29" type="dword" data="00ff00ff"/>
 					<value name="ColorTable30" type="dword" data="0000ffff"/>
 					<value name="ColorTable31" type="dword" data="00ffffff"/>
-				</key>
-				<key name="Palette2" modified="2015-03-19 13:53:09" build="150310">
-					<value name="Name" type="string" data="Solarized Dark"/>
-					<value name="TextColorIdx" type="hex" data="10"/>
-					<value name="BackColorIdx" type="hex" data="10"/>
-					<value name="PopTextColorIdx" type="hex" data="10"/>
-					<value name="PopBackColorIdx" type="hex" data="10"/>
-					<value name="ColorTable00" type="dword" data="00362b00"/>
-					<value name="ColorTable01" type="dword" data="00756e58"/>
-					<value name="ColorTable02" type="dword" data="00009985"/>
-					<value name="ColorTable03" type="dword" data="0098a12a"/>
-					<value name="ColorTable04" type="dword" data="002f32dc"/>
-					<value name="ColorTable05" type="dword" data="00c4716c"/>
-					<value name="ColorTable06" type="dword" data="00164bcb"/>
-					<value name="ColorTable07" type="dword" data="00969483"/>
-					<value name="ColorTable08" type="dword" data="00586e75"/>
-					<value name="ColorTable09" type="dword" data="00d28b26"/>
-					<value name="ColorTable10" type="dword" data="00009985"/>
-					<value name="ColorTable11" type="dword" data="0098a12a"/>
-					<value name="ColorTable12" type="dword" data="002f32dc"/>
-					<value name="ColorTable13" type="dword" data="008236d3"/>
-					<value name="ColorTable14" type="dword" data="000089b5"/>
-					<value name="ColorTable15" type="dword" data="00a1a193"/>
 				</key>
 				<key name="Palette3" modified="2021-09-06 13:31:26" build="210905">
 					<value name="Name" type="string" data="Solarized fixed"/>

--- a/windows/ConEmu.xml
+++ b/windows/ConEmu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <key name="Software">
 	<key name="ConEmu">
-		<key name=".Vanilla" modified="2020-05-31 11:10:47" build="191012">
+		<key name=".Vanilla" modified="2021-09-06 14:08:13" build="210905">
 			<value name="StartType" type="hex" data="02"/>
 			<value name="CmdLine" type="string" data=""/>
 			<value name="StartTasksFile" type="string" data=""/>
@@ -9,16 +9,16 @@
 			<value name="StartFarFolders" type="hex" data="00"/>
 			<value name="StartFarEditors" type="hex" data="00"/>
 			<value name="ColorTable00" type="dword" data="00362b00"/>
-			<value name="ColorTable01" type="dword" data="00423607"/>
-			<value name="ColorTable02" type="dword" data="00808000"/>
-			<value name="ColorTable03" type="dword" data="00a48231"/>
+			<value name="ColorTable01" type="dword" data="00d28b26"/>
+			<value name="ColorTable02" type="dword" data="00009985"/>
+			<value name="ColorTable03" type="dword" data="0098a12a"/>
 			<value name="ColorTable04" type="dword" data="00164bcb"/>
-			<value name="ColorTable05" type="dword" data="00b6369c"/>
-			<value name="ColorTable06" type="dword" data="00009985"/>
+			<value name="ColorTable05" type="dword" data="008236d3"/>
+			<value name="ColorTable06" type="dword" data="000089b5"/>
 			<value name="ColorTable07" type="dword" data="00d5e8ee"/>
 			<value name="ColorTable08" type="dword" data="00a1a193"/>
 			<value name="ColorTable09" type="dword" data="00d28b26"/>
-			<value name="ColorTable10" type="dword" data="0036b64f"/>
+			<value name="ColorTable10" type="dword" data="00009985"/>
 			<value name="ColorTable11" type="dword" data="0098a12a"/>
 			<value name="ColorTable12" type="dword" data="002f32dc"/>
 			<value name="ColorTable13" type="dword" data="008236d3"/>
@@ -87,15 +87,16 @@
 			<value name="StoreTaskbarCommands" type="hex" data="00"/>
 			<value name="SaveCmdHistory" type="hex" data="01"/>
 			<value name="CmdLineHistory" type="multi">
-				<line data="{PowerShell::Core (Admin)}"/>
-				<line data="{PowerShell::PowerShell (Admin)}"/>
 				<line data="{PowerShell::PowerShell}"/>
 				<line data="{PowerShell::Core}"/>
-				<line data="{cmd::cmd}"/>
 				<line data="{dev::VS Dev}"/>
+				<line data="{PowerShell::Core (Admin)}"/>
+				<line data="{PowerShell::PowerShell (Admin)}"/>
+				<line data="{cmd::cmd}"/>
 				<line data="{cmd::cmd (Admin)}"/>
 				<line data="{CBT::dp-main-2}"/>
 				<line data="{CBT::dp-main}"/>
+				<line data="{bash::cygwin}"/>
 				<line data="{CBT::dp-main-4}"/>
 				<line data="{CBT::dp-main-3}"/>
 				<line data="{PowerShell}"/>
@@ -161,10 +162,10 @@
 			<value name="UseCurrentSizePos" type="hex" data="01"/>
 			<value name="WindowMode" type="dword" data="0000051f"/>
 			<value name="ConWnd Width" type="dword" data="00000075"/>
-			<value name="ConWnd Height" type="dword" data="00000026"/>
+			<value name="ConWnd Height" type="dword" data="00000024"/>
 			<value name="Cascaded" type="hex" data="01"/>
-			<value name="ConWnd X" type="long" data="1078"/>
-			<value name="ConWnd Y" type="long" data="87"/>
+			<value name="ConWnd X" type="long" data="574"/>
+			<value name="ConWnd Y" type="long" data="122"/>
 			<value name="16bit Height" type="ulong" data="0"/>
 			<value name="AutoSaveSizePos" type="hex" data="00"/>
 			<value name="IntegralSize" type="hex" data="00"/>
@@ -397,7 +398,7 @@
 			<value name="Update.DownloadPath" type="string" data="%TEMP%\ConEmu"/>
 			<value name="Update.LeavePackages" type="hex" data="00"/>
 			<value name="Update.PostUpdateCmd" type="string" data="echo Last successful update&gt;ConEmuUpdate.info &amp;&amp; date /t&gt;&gt;ConEmuUpdate.info &amp;&amp; time /t&gt;&gt;ConEmuUpdate.info"/>
-			<key name="HotKeys" modified="2018-05-05 15:21:42" build="180503">
+			<key name="HotKeys" modified="2021-09-06 10:15:01" build="210905">
 				<value name="KeyMacroVersion" type="hex" data="02"/>
 				<value name="Multi.Modifier" type="dword" data="0000005b"/>
 				<value name="Multi.ArrowsModifier" type="dword" data="0000005b"/>
@@ -593,6 +594,9 @@
 				<value name="CheckUpdates" type="dword" data="00105b55"/>
 				<value name="Multi.NewWndConfirm" type="dword" data="00000000"/>
 				<value name="CloseToRightKey" type="dword" data="00000000"/>
+				<value name="Key.EditMenu" type="dword" data="00000000"/>
+				<value name="Key.EditMenu2" type="dword" data="00000000"/>
+				<value name="SetFocusParent" type="dword" data="0000a01b"/>
 			</key>
 			<key name="Tasks" modified="2020-05-31 11:10:47" build="191012">
 				<value name="Count" type="long" data="11"/>
@@ -700,8 +704,8 @@
 			<key name="Apps" modified="2017-11-13 12:23:12" build="171109">
 				<value name="Count" type="long" data="0"/>
 			</key>
-			<key name="Colors" modified="2017-11-13 12:23:12" build="171109">
-				<value name="Count" type="long" data="1"/>
+			<key name="Colors" modified="2021-09-06 13:31:26" build="210905">
+				<value name="Count" type="long" data="3"/>
 				<key name="Palette1" modified="2018-05-05 15:21:42" build="180503">
 					<value name="Name" type="string" data="#Attached:cmd"/>
 					<value name="ExtendColors" type="hex" data="00"/>
@@ -743,6 +747,52 @@
 					<value name="ColorTable30" type="dword" data="0000ffff"/>
 					<value name="ColorTable31" type="dword" data="00ffffff"/>
 				</key>
+				<key name="Palette2" modified="2015-03-19 13:53:09" build="150310">
+					<value name="Name" type="string" data="Solarized Dark"/>
+					<value name="TextColorIdx" type="hex" data="10"/>
+					<value name="BackColorIdx" type="hex" data="10"/>
+					<value name="PopTextColorIdx" type="hex" data="10"/>
+					<value name="PopBackColorIdx" type="hex" data="10"/>
+					<value name="ColorTable00" type="dword" data="00362b00"/>
+					<value name="ColorTable01" type="dword" data="00756e58"/>
+					<value name="ColorTable02" type="dword" data="00009985"/>
+					<value name="ColorTable03" type="dword" data="0098a12a"/>
+					<value name="ColorTable04" type="dword" data="002f32dc"/>
+					<value name="ColorTable05" type="dword" data="00c4716c"/>
+					<value name="ColorTable06" type="dword" data="00164bcb"/>
+					<value name="ColorTable07" type="dword" data="00969483"/>
+					<value name="ColorTable08" type="dword" data="00586e75"/>
+					<value name="ColorTable09" type="dword" data="00d28b26"/>
+					<value name="ColorTable10" type="dword" data="00009985"/>
+					<value name="ColorTable11" type="dword" data="0098a12a"/>
+					<value name="ColorTable12" type="dword" data="002f32dc"/>
+					<value name="ColorTable13" type="dword" data="008236d3"/>
+					<value name="ColorTable14" type="dword" data="000089b5"/>
+					<value name="ColorTable15" type="dword" data="00a1a193"/>
+				</key>
+				<key name="Palette3" modified="2021-09-06 13:31:26" build="210905">
+					<value name="Name" type="string" data="Solarized fixed"/>
+					<value name="TextColorIdx" type="hex" data="10"/>
+					<value name="BackColorIdx" type="hex" data="10"/>
+					<value name="PopTextColorIdx" type="hex" data="10"/>
+					<value name="PopBackColorIdx" type="hex" data="10"/>
+					<value name="ColorTable00" type="dword" data="00362b00"/>
+					<value name="ColorTable01" type="dword" data="00d28b26"/>
+					<value name="ColorTable02" type="dword" data="00009985"/>
+					<value name="ColorTable03" type="dword" data="0098a12a"/>
+					<value name="ColorTable04" type="dword" data="00164bcb"/>
+					<value name="ColorTable05" type="dword" data="008236d3"/>
+					<value name="ColorTable06" type="dword" data="000089b5"/>
+					<value name="ColorTable07" type="dword" data="00d5e8ee"/>
+					<value name="ColorTable08" type="dword" data="00a1a193"/>
+					<value name="ColorTable09" type="dword" data="00d28b26"/>
+					<value name="ColorTable10" type="dword" data="00009985"/>
+					<value name="ColorTable11" type="dword" data="0098a12a"/>
+					<value name="ColorTable12" type="dword" data="002f32dc"/>
+					<value name="ColorTable13" type="dword" data="008236d3"/>
+					<value name="ColorTable14" type="dword" data="000089b5"/>
+					<value name="ColorTable15" type="dword" data="00e3f6fd"/>
+				</key>
 			</key>
 			<value name="StartCreateDelay" type="ulong" data="100"/>
 			<value name="DefaultTerminalDebugLog" type="hex" data="00"/>
@@ -783,6 +833,7 @@
 			<value name="AutoReloadEnvironment" type="hex" data="01"/>
 			<value name="AutoTrimSingleLine" type="hex" data="00"/>
 			<value name="StatusBar.Hide.InputGrouping" type="hex" data="00"/>
+			<value name="ResetTerminalConfirm" type="hex" data="01"/>
 		</key>
 	</key>
 </key>

--- a/windows/windowsterminal-settings.json
+++ b/windows/windowsterminal-settings.json
@@ -1,31 +1,53 @@
 {
     "$schema": "https://aka.ms/terminal-profiles-schema",
-    "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-    "copyOnSelect": false,
-    "copyFormatting": false,
-    "schemes": [],
-    "profiles":
-    {
-        "defaults":
+    "actions": [
         {
-            "fontFace": "Consolas NF",
-            "cursorShape": "filledBox",
-            "cursorColor": "#268bd2", 
-            "colorScheme": "Solarized Dark"
+            "command": {
+                "action": "copy",
+                "singleLine": false
+            },
+            "keys": "ctrl+c"
         },
-        "list":
-        [
+        {
+            "command": "find",
+            "keys": "ctrl+shift+f"
+        },
+        {
+            "command": "paste",
+            "keys": "ctrl+v"
+        },
+        {
+            "command": {
+                "action": "splitPane",
+                "split": "auto",
+                "splitMode": "duplicate"
+            },
+            "keys": "alt+shift+d"
+        }
+    ],
+    "copyFormatting": "none",
+    "copyOnSelect": false,
+    "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+    "profiles": {
+        "defaults": {
+            "colorScheme": "Solarized Dark",
+            "cursorColor": "#268BD2",
+            "cursorShape": "filledBox",
+            "fontFace": "Consolas NF"
+        },
+        "list": [
             {
+                "colorScheme": "Solarized Dark",
                 "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
                 "hidden": false,
                 "name": "PowerShell",
                 "source": "Windows.Terminal.PowershellCore"
             },
             {
-                "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
-                "name": "Windows PowerShell",
                 "commandline": "powershell.exe",
-                "hidden": false
+                "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+                "hidden": false,
+                "name": "Windows PowerShell"
             },
             {
                 "guid": "{2c4de342-38b7-51cf-b940-2309a097f518}",
@@ -34,10 +56,10 @@
                 "source": "Windows.Terminal.Wsl"
             },
             {
-                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-                "name": "Command Prompt",
                 "commandline": "cmd.exe",
-                "hidden": false
+                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                "hidden": false,
+                "name": "Command Prompt"
             },
             {
                 "guid": "{b453ae62-4e3d-5e58-b989-0a998ec441b8}",
@@ -47,11 +69,213 @@
             }
         ]
     },
-    "keybindings":
-    [
-        { "command": {"action": "copy", "singleLine": false }, "keys": "ctrl+c" },
-        { "command": "paste", "keys": "ctrl+v" },
-        { "command": "find", "keys": "ctrl+shift+f" },
-        { "command": { "action": "splitPane", "split": "auto", "splitMode": "duplicate" }, "keys": "alt+shift+d" }
+    "schemes": [
+        {
+            "background": "#0C0C0C",
+            "black": "#0C0C0C",
+            "blue": "#0037DA",
+            "brightBlack": "#767676",
+            "brightBlue": "#3B78FF",
+            "brightCyan": "#61D6D6",
+            "brightGreen": "#16C60C",
+            "brightPurple": "#B4009E",
+            "brightRed": "#E74856",
+            "brightWhite": "#F2F2F2",
+            "brightYellow": "#F9F1A5",
+            "cursorColor": "#FFFFFF",
+            "cyan": "#3A96DD",
+            "foreground": "#CCCCCC",
+            "green": "#13A10E",
+            "name": "Campbell",
+            "purple": "#881798",
+            "red": "#C50F1F",
+            "selectionBackground": "#FFFFFF",
+            "white": "#CCCCCC",
+            "yellow": "#C19C00"
+        },
+        {
+            "background": "#012456",
+            "black": "#0C0C0C",
+            "blue": "#0037DA",
+            "brightBlack": "#767676",
+            "brightBlue": "#3B78FF",
+            "brightCyan": "#61D6D6",
+            "brightGreen": "#16C60C",
+            "brightPurple": "#B4009E",
+            "brightRed": "#E74856",
+            "brightWhite": "#F2F2F2",
+            "brightYellow": "#F9F1A5",
+            "cursorColor": "#FFFFFF",
+            "cyan": "#3A96DD",
+            "foreground": "#CCCCCC",
+            "green": "#13A10E",
+            "name": "Campbell Powershell",
+            "purple": "#881798",
+            "red": "#C50F1F",
+            "selectionBackground": "#FFFFFF",
+            "white": "#CCCCCC",
+            "yellow": "#C19C00"
+        },
+        {
+            "background": "#282C34",
+            "black": "#282C34",
+            "blue": "#61AFEF",
+            "brightBlack": "#5A6374",
+            "brightBlue": "#61AFEF",
+            "brightCyan": "#56B6C2",
+            "brightGreen": "#98C379",
+            "brightPurple": "#C678DD",
+            "brightRed": "#E06C75",
+            "brightWhite": "#DCDFE4",
+            "brightYellow": "#E5C07B",
+            "cursorColor": "#FFFFFF",
+            "cyan": "#56B6C2",
+            "foreground": "#DCDFE4",
+            "green": "#98C379",
+            "name": "One Half Dark",
+            "purple": "#C678DD",
+            "red": "#E06C75",
+            "selectionBackground": "#FFFFFF",
+            "white": "#DCDFE4",
+            "yellow": "#E5C07B"
+        },
+        {
+            "background": "#FAFAFA",
+            "black": "#383A42",
+            "blue": "#0184BC",
+            "brightBlack": "#4F525D",
+            "brightBlue": "#61AFEF",
+            "brightCyan": "#56B5C1",
+            "brightGreen": "#98C379",
+            "brightPurple": "#C577DD",
+            "brightRed": "#DF6C75",
+            "brightWhite": "#FFFFFF",
+            "brightYellow": "#E4C07A",
+            "cursorColor": "#4F525D",
+            "cyan": "#0997B3",
+            "foreground": "#383A42",
+            "green": "#50A14F",
+            "name": "One Half Light",
+            "purple": "#A626A4",
+            "red": "#E45649",
+            "selectionBackground": "#FFFFFF",
+            "white": "#FAFAFA",
+            "yellow": "#C18301"
+        },
+        {
+            "background": "#002B36",
+            "black": "#002B36",
+            "blue": "#268BD2",
+            "brightBlack": "#073642",
+            "brightBlue": "#839496",
+            "brightCyan": "#93A1A1",
+            "brightGreen": "#586E75",
+            "brightPurple": "#6C71C4",
+            "brightRed": "#CB4B16",
+            "brightWhite": "#FDF6E3",
+            "brightYellow": "#657B83",
+            "cursorColor": "#FFFFFF",
+            "cyan": "#2AA198",
+            "foreground": "#839496",
+            "green": "#859900",
+            "name": "Solarized Dark",
+            "purple": "#D33682",
+            "red": "#DC322F",
+            "selectionBackground": "#FFFFFF",
+            "white": "#EEE8D5",
+            "yellow": "#B58900"
+        },
+        {
+            "background": "#FDF6E3",
+            "black": "#002B36",
+            "blue": "#268BD2",
+            "brightBlack": "#073642",
+            "brightBlue": "#839496",
+            "brightCyan": "#93A1A1",
+            "brightGreen": "#586E75",
+            "brightPurple": "#6C71C4",
+            "brightRed": "#CB4B16",
+            "brightWhite": "#FDF6E3",
+            "brightYellow": "#657B83",
+            "cursorColor": "#002B36",
+            "cyan": "#2AA198",
+            "foreground": "#657B83",
+            "green": "#859900",
+            "name": "Solarized Light",
+            "purple": "#D33682",
+            "red": "#DC322F",
+            "selectionBackground": "#FFFFFF",
+            "white": "#EEE8D5",
+            "yellow": "#B58900"
+        },
+        {
+            "background": "#000000",
+            "black": "#000000",
+            "blue": "#3465A4",
+            "brightBlack": "#555753",
+            "brightBlue": "#729FCF",
+            "brightCyan": "#34E2E2",
+            "brightGreen": "#8AE234",
+            "brightPurple": "#AD7FA8",
+            "brightRed": "#EF2929",
+            "brightWhite": "#EEEEEC",
+            "brightYellow": "#FCE94F",
+            "cursorColor": "#FFFFFF",
+            "cyan": "#06989A",
+            "foreground": "#D3D7CF",
+            "green": "#4E9A06",
+            "name": "Tango Dark",
+            "purple": "#75507B",
+            "red": "#CC0000",
+            "selectionBackground": "#FFFFFF",
+            "white": "#D3D7CF",
+            "yellow": "#C4A000"
+        },
+        {
+            "background": "#FFFFFF",
+            "black": "#000000",
+            "blue": "#3465A4",
+            "brightBlack": "#555753",
+            "brightBlue": "#729FCF",
+            "brightCyan": "#34E2E2",
+            "brightGreen": "#8AE234",
+            "brightPurple": "#AD7FA8",
+            "brightRed": "#EF2929",
+            "brightWhite": "#EEEEEC",
+            "brightYellow": "#FCE94F",
+            "cursorColor": "#000000",
+            "cyan": "#06989A",
+            "foreground": "#555753",
+            "green": "#4E9A06",
+            "name": "Tango Light",
+            "purple": "#75507B",
+            "red": "#CC0000",
+            "selectionBackground": "#FFFFFF",
+            "white": "#D3D7CF",
+            "yellow": "#C4A000"
+        },
+        {
+            "background": "#000000",
+            "black": "#000000",
+            "blue": "#000080",
+            "brightBlack": "#808080",
+            "brightBlue": "#0000FF",
+            "brightCyan": "#00FFFF",
+            "brightGreen": "#00FF00",
+            "brightPurple": "#FF00FF",
+            "brightRed": "#FF0000",
+            "brightWhite": "#FFFFFF",
+            "brightYellow": "#FFFF00",
+            "cursorColor": "#FFFFFF",
+            "cyan": "#008080",
+            "foreground": "#C0C0C0",
+            "green": "#008000",
+            "name": "Vintage",
+            "purple": "#800080",
+            "red": "#800000",
+            "selectionBackground": "#FFFFFF",
+            "white": "#C0C0C0",
+            "yellow": "#808000"
+        }
     ]
 }

--- a/windows/windowsterminal-settings.json
+++ b/windows/windowsterminal-settings.json
@@ -3,7 +3,7 @@
     "copyFormatting": "none",
     "copyOnSelect": true,
     "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-    "actions": [
+    "keybindings": [
         {
             "command": {
                 "action": "globalSummon",


### PR DESCRIPTION
* Set proper 4-bit color mapping (named terminal colors) in ConEmu.
* Use ANSI sequences to consistently color PowerShell prompt.
* Use RGB hex values to set posh-git prompt colors.